### PR TITLE
Log uncaught errors in background.ts

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -56,6 +56,10 @@ Electron.app.setAppLogsPath(paths.logs);
 
 const console = Logging.background;
 
+process.on('uncaughtException', function (err) {
+  console.log(err);
+})
+
 if (!Electron.app.requestSingleInstanceLock()) {
   process.exit(201);
 }


### PR DESCRIPTION
Hopefully this allows us to track down when the renderer crashes and leaves us with an empty white window.