### PR TITLE
Comment out virtualization check

### DIFF
--- a/pkg/rancher-desktop/backend/lima.ts
+++ b/pkg/rancher-desktop/backend/lima.ts
@@ -1844,7 +1844,7 @@ export default class LimaBackend extends events.EventEmitter implements VMBacken
       try {
         this.ensureArchitectureMatch();
         await Promise.all([
-          this.progressTracker.action('Ensuring virtualization is supported', 50, this.ensureVirtualizationSupported()),
+          // this.progressTracker.action('Ensuring virtualization is supported', 50, this.ensureVirtualizationSupported()),
           this.progressTracker.action('Updating cluster configuration', 50, this.updateConfig(this.#adminAccess)),
         ]);
 


### PR DESCRIPTION
Lima is supposed to fall back to TCG if HVF emulation is not available. Performance will be bad, but this might allow running on an AMD Hackintosh.