### PR TITLE
Redirect Electron userData dirctory to be under the AppData dir

### DIFF
--- a/background.ts
+++ b/background.ts
@@ -56,6 +56,7 @@ import * as window from '@pkg/window';
 import { closeDashboard, openDashboard } from '@pkg/window/dashboard';
 import { openPreferences, preferencesSetDirtyFlag } from '@pkg/window/preferences';
 
+Electron.app.setPath('userData', path.join(paths.appHome, 'electron'));
 Electron.app.setPath('cache', paths.cache);
 Electron.app.setAppLogsPath(paths.logs);
 


### PR DESCRIPTION
That way it will automatically be removed by factory-reset, and users won't be confused by having both 'Rancher Desktop' and 'rancher-desktop' AppData directories.