### PR TITLE
networking: make per-packet vm-switch tracing opt-in (decoupled from --debug)

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -712,6 +712,7 @@ VMGUID
 VMID
 vmnet
 vmsplice
+VMSWITCH
 vmwarevsphere
 vmx
 vnc

--- a/docs/networking/windows/rancher-desktop-networking.md
+++ b/docs/networking/windows/rancher-desktop-networking.md
@@ -67,6 +67,8 @@ Additionally, it calls unshare with provided arguments through [---unshare-args]
 
 - **debug**: enable the debug logging
 
+- **trace-packets**: Forward per-packet tracing to the `vm-switch` process (see the `vm-switch` flag below). Off by default; very verbose.
+
 - **tap-interface**: The name of the tap interface that is created by the vm-switch upon startup, e.g., `eth0`, `eth1`. This value is passed to the `vm-switch` process when the `network-setup` attempts to start it. If no value is provided, the default name of `eth0` is used.
 
 - **subnet**: A subnet range with a CIDR suffix that is associated with the tap interface in the network namespace. If it is not defined, it uses `192.168.127.0/24` as the default range. It is important to note that this value needs to match the [subnet](https://github.com/rancher-sandbox/rancher-desktop/blob/6abacdc804d6414f17439a97f22e0c9c87f6249d/cmd/host/switch_windows.go#L54) flag in the `host-switch`.
@@ -90,6 +92,8 @@ The tap device forwards the Ethernet frames over [vsock](https://wiki.qemu.org/F
 ## Supported Flags:
 
 - **debug**: Enable the debug logging
+
+- **trace-packets**: Log a decoded dump of every packet in both directions. **Off by default** and deliberately independent of `-debug`, because it is extremely verbose and writes to `vm-switch.log` on the data-plane hot path. Enable it at startup by launching Rancher Desktop with `RD_VMSWITCH_TRACE=1` in the environment, or toggle it on/off at runtime (without restarting the network stack) by sending `SIGUSR1` to the `vm-switch` process. `vm-switch` runs in the top-level WSL (init) PID namespace, so signal it from there — e.g. `wsl -d rancher-desktop --exec sh -c 'kill -USR1 $(pgrep vm-switch)'` — **not** via `rdctl shell`, which enters the Rancher Desktop network namespace where `vm-switch` is not visible.
 
 - **tap-interface**: Tap interface name to create, eg. eth0, eth1
 

--- a/pkg/rancher-desktop/assets/scripts/wsl-init
+++ b/pkg/rancher-desktop/assets/scripts/wsl-init
@@ -21,7 +21,7 @@ if [ $$ -ne "1" ]; then
     # from WSL.
     exec /usr/local/bin/network-setup --logfile "$NETWORK_SETUP_LOG" \
     --vm-switch-path /usr/local/bin/vm-switch --vm-switch-logfile \
-    "$VM_SWITCH_LOG" ${RD_DEBUG:+-debug} --unshare-arg "${0}"
+    "$VM_SWITCH_LOG" ${RD_DEBUG:+-debug} ${RD_VMSWITCH_TRACE:+-trace-packets} --unshare-arg "${0}"
 fi
 
 # Mark directories that we will need to bind mount as shared mounts.

--- a/pkg/rancher-desktop/backend/wsl.ts
+++ b/pkg/rancher-desktop/backend/wsl.ts
@@ -1083,13 +1083,20 @@ export default class WSLBackend extends events.EventEmitter implements VMBackend
     this.process?.kill('SIGTERM');
     const env: Record<string, string> = {
       ...process.env,
-      WSLENV:           `${ process.env.WSLENV }:DISTRO_DATA_DIRS:LOG_DIR/p:RD_DEBUG`,
+      WSLENV:           `${ process.env.WSLENV }:DISTRO_DATA_DIRS:LOG_DIR/p:RD_DEBUG:RD_VMSWITCH_TRACE`,
       DISTRO_DATA_DIRS: DISTRO_DATA_DIRS.join(':'),
       LOG_DIR:          paths.logs,
     };
 
     if (this.debug) {
       env.RD_DEBUG = '1';
+    }
+    // Per-packet vm-switch tracing is opt-in and deliberately decoupled from
+    // --debug (it is extremely verbose and can fill the disk). Enable it by
+    // setting RD_VMSWITCH_TRACE in the environment; it can also be toggled at
+    // runtime by sending SIGUSR1 to the vm-switch process.
+    if (process.env.RD_VMSWITCH_TRACE) {
+      env.RD_VMSWITCH_TRACE = '1';
     }
     this.process = childProcess.spawn('wsl.exe',
       ['--distribution', INSTANCE_NAME, '--exec', '/usr/local/bin/wsl-init'],

--- a/src/go/networking/cmd/network/setup_linux.go
+++ b/src/go/networking/cmd/network/setup_linux.go
@@ -43,6 +43,7 @@ import (
 
 var options struct {
 	debug            bool
+	tracePackets     bool
 	vmSwitchPath     string
 	unshareArg       string
 	vmSwitchLogFile  string
@@ -204,6 +205,7 @@ func main() {
 
 func initializeFlags() {
 	flag.BoolVar(&options.debug, "debug", false, "enable additional debugging")
+	flag.BoolVar(&options.tracePackets, "trace-packets", false, "forward per-packet tracing to the vm-switch process")
 	flag.StringVar(&options.namespaceService, "namespace-service", defaultNamespaceService, "systemd service which creates the network namespace")
 	flag.StringVar(&options.tapIface, "tap-interface", defaultTapDevice, "tap interface name, eg. eth0, eth1")
 	flag.StringVar(&options.subnet, "subnet", config.DefaultSubnet,
@@ -263,6 +265,9 @@ func configureVMSwitch(
 	}
 	if options.debug {
 		args = append(args, "-debug")
+	}
+	if options.tracePackets {
+		args = append(args, "-trace-packets")
 	}
 
 	//nolint:gosec // Arguments are ultimately controlled by our configs.

--- a/src/go/networking/cmd/vm/switch_linux.go
+++ b/src/go/networking/cmd/vm/switch_linux.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -55,8 +56,17 @@ const (
 	maxMTU           = 4000
 )
 
+var (
+	// traceFlag is the startup value of the -trace-packets flag.
+	traceFlag bool
+	// tracePackets gates per-packet logging. It is initialized from traceFlag
+	// and can be toggled at runtime by sending SIGUSR1 to this process.
+	tracePackets atomic.Bool
+)
+
 func main() {
 	flag.BoolVar(&debug, "debug", false, "enable debug flag")
+	flag.BoolVar(&traceFlag, "trace-packets", false, "log a decode of every packet (very verbose); can also be toggled at runtime via SIGUSR1")
 	flag.StringVar(&tapIface, "tap-interface", defaultTapDevice, "tap interface name, eg. eth0, eth1")
 	flag.IntVar(&vsockFD, "vsock-fd", defaultVsockFD, "file descriptor for vsock connection")
 	flag.StringVar(&dhcpScript, "dhcp-script", "", "script to run on DHCP events")
@@ -74,6 +84,27 @@ func main() {
 	if debug {
 		logrus.SetLevel(logrus.DebugLevel)
 	}
+
+	// Per-packet tracing is intentionally separate from -debug (it is extremely
+	// verbose and can fill the disk). It starts in the state requested by
+	// -trace-packets and can be flipped on/off at runtime, without restarting
+	// the network stack, by sending SIGUSR1.
+	//
+	// vm-switch runs in the top-level WSL (init) PID namespace, so the signal
+	// must be sent from there, e.g. from the Windows host:
+	//   wsl -d rancher-desktop --exec sh -c 'kill -USR1 $(pgrep vm-switch)'
+	// It is NOT reachable via `rdctl shell`, which enters the Rancher Desktop
+	// network namespace where vm-switch is not visible (pgrep finds nothing).
+	tracePackets.Store(traceFlag)
+	traceSigCh := make(chan os.Signal, 1)
+	signal.Notify(traceSigCh, syscall.SIGUSR1)
+	go func() {
+		for range traceSigCh {
+			enabled := !tracePackets.Load()
+			tracePackets.Store(enabled)
+			logrus.Infof("SIGUSR1 received: per-packet tracing is now %t", enabled)
+		}
+	}()
 
 	// the FD is passed-in as an extra arg from exec.Command
 	// of the parent process. This is for the AF_VSOCK connection that
@@ -225,9 +256,9 @@ func rx(ctx context.Context, conn io.Writer, tap *water.Interface, errCh chan er
 				return
 			}
 
-			if debug {
+			if tracePackets.Load() {
 				packet := gopacket.NewPacket(frame, layers.LayerTypeEthernet, gopacket.Default)
-				logrus.Infof("wrote packet (vm -> host %d): %s", size, packet.String())
+				logrus.Infof("wrote packet (vm -> host %d): %s", n, packet.String())
 			}
 		}
 	}
@@ -273,7 +304,7 @@ func tx(ctx context.Context, conn io.Reader, tap *water.Interface, errCh chan er
 				return
 			}
 
-			if debug {
+			if tracePackets.Load() {
 				packet := gopacket.NewPacket(buf[:size], layers.LayerTypeEthernet, gopacket.Default)
 				logrus.Infof("read packet (host -> vm %d): %s", size, packet.String())
 			}


### PR DESCRIPTION
## Summary

`vm-switch` logs a full `gopacket` decode of every packet in both directions whenever it runs with `-debug`. Because Rancher Desktop's `--debug` propagates all the way down to that process, every debug session turned into a per-packet firehose on the data-plane hot path. Two problems followed:

- **Performance:** each packet incurred a synchronous `gopacket.NewPacket(...)` decode plus a synchronous `logrus.Infof` write, on the rx/tx hot loops.
- **Unbounded disk:** `vm-switch.log` grew without any cap (observed >100 MB in a single session), even though most `--debug` users only want ordinary debug-level logs.

This change splits per-packet tracing out from `--debug` so it can be enabled deliberately, defaults to off, and can be toggled live.

> Self-review PR on a personal fork before filing upstream (base `main` ← `vmswitch-packet-trace-opt-in`).

## Root cause

`--debug` was overloaded. The chain `--debug` → `RD_DEBUG` (host env) → `wsl-init` `${RD_DEBUG:+-debug}` → `network-setup -debug` → `vm-switch -debug` meant the same flag that raised the log level *also* gated per-packet capture. The trace lines were emitted at `INFO` on the hot path, so they fired regardless of log level once the `if debug` guard was true, with no way to attenuate short of restarting the network stack.

## What changed

- **`-trace-packets` flag + atomic gate** (`src/go/networking/cmd/vm/switch_linux.go`): a new `-trace-packets` flag seeds an `atomic.Bool` (`tracePackets`). The two hot-path sites now read `tracePackets.Load()` instead of `if debug`. The remaining `if debug` only sets the log level — `-debug` no longer triggers any packet capture.
- **SIGUSR1 runtime toggle** (`switch_linux.go`): a dedicated `traceSigCh` registered for *only* `SIGUSR1`, with a single writer goroutine flipping the gate and logging the new state. It is disjoint from the existing exit handler (`Interrupt`/`SIGTERM`/`SIGINT`), so the signal sets never cross-deliver. SIGUSR1 was confirmed unused across the Go runtime and the full compiled-in dependency graph.
- **`RD_VMSWITCH_TRACE` env var** (`pkg/rancher-desktop/backend/wsl.ts`): added to `WSLENV` (mirroring `RD_DEBUG`) and set in its own block, **intentionally decoupled from `this.debug`**.
- **Plumbing** (`pkg/rancher-desktop/assets/scripts/wsl-init`, `src/go/networking/cmd/network/setup_linux.go`): `wsl-init` forwards `${RD_VMSWITCH_TRACE:+-trace-packets}` (nounset-safe, matching the adjacent `${RD_DEBUG:+-debug}`); `network-setup` registers `-trace-packets` and appends it to the `vm-switch` argv only when set.
- **Docs** (`docs/networking/windows/rancher-desktop-networking.md`): documented `-trace-packets` in both the `network-setup` and `vm-switch` flag sections, including the `SIGUSR1` toggle and `RD_VMSWITCH_TRACE`.
- **Drive-by fix:** the `rx` trace line logged the 2-byte little-endian length *slice* with `%d` (printing e.g. `[60 0]`); it now logs the decoded `int` length, matching `tx`.

**Design note:** `RD_VMSWITCH_TRACE` is an env var by design, not a `settings.ts` field. Per-packet tracing is an operator/debugging capture tool, not an end-user preference, and a Settings field would require schema/migration/UI/persistence churn plus a renderer→main→guest path that does not exist today. The SIGUSR1 toggle already covers the "capture for a few seconds, then turn it off" workflow without any settings surface. (It is documented in the networking docs rather than `docs/development/env.md`, which is explicitly for variables "not meant to be set by users".)

## How to use it

- **At startup:** launch Rancher Desktop with `RD_VMSWITCH_TRACE=1` in the host environment. It plumbs through to `vm-switch -trace-packets` and tracing begins immediately.
- **Live toggle:** send `SIGUSR1` to the `vm-switch` process to flip tracing on/off without restarting the network stack. `vm-switch` runs in the **top-level WSL (init) PID namespace**, so signal it from there — `wsl -d rancher-desktop --exec sh -c 'kill -USR1 $(pgrep vm-switch)'` — **not** via `rdctl shell` (which enters the Rancher Desktop network namespace, where `vm-switch` is not visible; `pgrep` returns nothing there). The new state is logged (`SIGUSR1 received: per-packet tracing is now <true|false>`), so you can capture for a few seconds and turn it back off.

## Related issues

- **rancher-sandbox/rancher-desktop#5644** ("Can we get rid of 'debug' mode for logging?" — wants always-on debug info + log rotation so logs don't fill the disk). This change removes the vm-switch per-packet firehose, which was a major contributor to debug-mode log bloat — a step toward that goal, though not a full close (log rotation / always-on debug remain).
- **rancher-sandbox/rancher-desktop#1942** (a 264 GB lima `vmnet` stderr log on macOS). Same *class* of problem (an unbounded networking log) but a different component/platform; not addressed here.

Neither is *closed* by this PR.

## Validation

- `gofmt -l` clean; `GOOS=linux go build ./cmd/...` and `GOOS=linux go vet ./cmd/...` OK; `sh -n` on `wsl-init` OK.
- Full toggle chain (`wsl.ts` WSLENV → `RD_VMSWITCH_TRACE` → `wsl-init` `${RD_VMSWITCH_TRACE:+-trace-packets}` → `network-setup -trace-packets` → `vm-switch` atomic gate + SIGUSR1) traced and confirmed end to end.
- Commit carries a DCO `Signed-off-by`.

**Not yet runtime-tested.** Swapping `vm-switch` in a live VM is risky (it is the network data path), so the SIGUSR1 live toggle is the one path not exercised by build/vet and should get a smoke test (`kill -USR1` the `vm-switch` pid; confirm the log line and that tracing flips) before relying on it in the field.

## Follow-ups (not in this PR)

- A first-class Settings toggle + UI for persistent user control, layered on top of the env var if/when wanted.
- Log rotation / size cap on `vm-switch.log` (and the other networking logs) so even an intentional long trace cannot grow unbounded — this is the other half of rancher-sandbox/rancher-desktop#5644.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
